### PR TITLE
Convert single-quoted charlist to c-sigil

### DIFF
--- a/lib/debounce.ex
+++ b/lib/debounce.ex
@@ -210,7 +210,7 @@ defmodule Debounce do
       end
 
     :error_logger.error_msg(
-      '~p ~p received unexpected message: ~p~n',
+      ~c"~p ~p received unexpected message: ~p~n",
       [__MODULE__, proc, msg]
     )
 


### PR DESCRIPTION
Resolves the following warning on newer Elixir versions:

> warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead


The sigil ~c has been in the language since before the version in mix.exs, so this should be everything that needs to be done.